### PR TITLE
BUG: Added some fixes to CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if (NOT DEFINED HDF5_CXX_LIBRARIES)
    LIST(APPEND HDF5_CXX_LIBRARIES ${HDF5_hdf5_hl_LIBRARY})
 endif(NOT DEFINED HDF5_CXX_LIBRARIES)
 
-include_directories (${HDF5_CXX_INCLUDE_DIR})
+include_directories (${HDF5_CXX_INCLUDE_DIRS})
 
 # Is this here really necessary?
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,8 +68,9 @@ target_link_libraries (sanityck ${COMMON_LIBS} core)
 if (MPI_C_FOUND)
   add_executable (pjemris Mpi2Evolution.h
     Mpi2Evolution.cpp mpi_Model.h Model.h Model.cpp pjemris.cpp)
+  find_package(Threads REQUIRED)
   target_link_libraries (pjemris core ${COMMON_LIBS}
-	${MPI_C_LIBRARIES})  
+	${MPI_C_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
   target_compile_definitions (pjemris PRIVATE PARALLEL)
   if (MPI_C_COMPILE_FLAGS)
     set_target_properties(pjemris PROPERTIES


### PR DESCRIPTION
This commit fixes a few issues that prevented me from compiling
correctly on the University of Manchester CSF cluster. One issue was
around correctly linking HDF5 libraries, where it seems that the
HDF5_CXX_INCLUDE_DIR variable has been deprecated in favour of the
HDF5_CXX_INCLUDE_DIRS variable. The second issue relates to pjemris,
which requires the pthread library to be linked. This is a dependency of
the HDF5 library available through apt, so is normally linked
automatically. However when installing HDF5 from source (as I did not
have admin privileges) the same is not true. Instead I have added a
find_package(Threads) which will add the pthreads library independently.